### PR TITLE
Change proxypass for livelogs from https to http

### DIFF
--- a/frontend.conf
+++ b/frontend.conf
@@ -39,7 +39,7 @@ server {
         add_header X-Frame-Options SAMEORIGIN always;
         add_header Content-Security-Policy "default-src 'self' 'unsafe-inline' 'unsafe-eval' SSO_DNS; script-src 'self' 'unsafe-inline' 'unsafe-eval' SSO_DNS;";
 
-        proxy_pass          https://LIVELOGS_KIBANA_IP:5601;
+        proxy_pass          http://LIVELOGS_KIBANA_IP:5601;
         proxy_set_header    Host $host;
         proxy_set_header    X-Real-IP $remote_addr;
         proxy_set_header    X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -67,7 +67,7 @@ server {
         add_header X-Frame-Options SAMEORIGIN always;
         add_header Content-Security-Policy "default-src 'self' 'unsafe-inline' 'unsafe-eval' SSO_DNS; script-src 'self' 'unsafe-inline' 'unsafe-eval' SSO_DNS;";
 
-        proxy_pass          https://LIVELOGS_KIBANA_IP:5601;
+        proxy_pass          http://LIVELOGS_KIBANA_IP:5601;
         proxy_set_header    Host $host;
         proxy_set_header    X-Real-IP $remote_addr;
         proxy_set_header    X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
Currently proxypass with https to livelogs endpoint (IP) breaks and gives 502. 